### PR TITLE
Fix workflow: lees issue body via bestand ipv shell env var

### DIFF
--- a/.github/scripts/generate-lesson.py
+++ b/.github/scripts/generate-lesson.py
@@ -115,15 +115,21 @@ def parse_issue_body(body: str) -> dict:
     if current_field:
         result[current_field] = '\n'.join(current_value_lines).strip()
 
-    # Parse foto URLs
+    # Parse foto URLs — ondersteunt diverse GitHub image hosting domeinen
     foto_text = result.get('fotos_raw', '') or body
     foto_urls = re.findall(
-        r'https://(?:user-images\.githubusercontent\.com|github\.com)[^\s\)\"\']+\.(?:png|jpg|jpeg|gif|webp)',
+        r'https://(?:user-images\.githubusercontent\.com|private-user-images\.githubusercontent\.com|github\.user-content\.com|github\.com/user-attachments|github\.com)[^\s\)\"\']+\.(?:png|jpg|jpeg|gif|webp)',
         foto_text,
         re.IGNORECASE,
     )
+    # Markdown afbeeldingen: ![alt](url)
     foto_urls += re.findall(
         r'!\[.*?\]\((https://[^\s\)]+)\)',
+        foto_text,
+    )
+    # GitHub attachment URLs zonder extensie (bijv. github.com/user-attachments/assets/...)
+    foto_urls += re.findall(
+        r'https://github\.com/user-attachments/assets/[^\s\)\"\']+',
         foto_text,
     )
     seen = set()
@@ -327,10 +333,19 @@ def main():
     github_token = get_env('GITHUB_TOKEN')
     repo = get_env('GITHUB_REPOSITORY')
     issue_number = get_env('ISSUE_NUMBER')
-    issue_body = get_env('ISSUE_BODY')
     issue_author = get_env('ISSUE_AUTHOR')
 
+    # Issue body: lees uit bestand (veiliger dan env var bij multiline content)
+    issue_body_file = os.environ.get('ISSUE_BODY_FILE', '').strip()
+    if issue_body_file and Path(issue_body_file).exists():
+        issue_body = Path(issue_body_file).read_text(encoding='utf-8')
+        print(f"  Issue body gelezen uit bestand: {issue_body_file} ({len(issue_body)} chars)")
+    else:
+        issue_body = get_env('ISSUE_BODY')
+        print(f"  Issue body gelezen uit env var ({len(issue_body)} chars)")
+
     print(f"Verwerk issue #{issue_number} van {issue_author}...")
+    print(f"  Issue body (eerste 500 chars): {issue_body[:500]}")
 
     # Parse issue
     parsed = parse_issue_body(issue_body)
@@ -340,11 +355,14 @@ def main():
     fotos = parsed['fotos']
     extra = parsed['extra']
 
+    print(f"  Parsed: titel='{titel}', vak='{vak}', niveau='{niveau}', fotos={len(fotos)}, extra={len(extra)} chars")
+
     if not titel:
         print("FOUT: Geen titel gevonden in het issue.")
         sys.exit(1)
     if not fotos:
         print("FOUT: Geen foto's gevonden in het issue.")
+        print(f"  Volledige issue body:\n{issue_body}")
         sys.exit(1)
 
     print(f"  Titel: {titel}")

--- a/.github/workflows/generate-lesson.yml
+++ b/.github/workflows/generate-lesson.yml
@@ -76,7 +76,10 @@ jobs:
           AI_PROVIDER: ${{ inputs.ai_provider || 'claude' }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
+          set -euo pipefail
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
@@ -85,19 +88,24 @@ jobs:
             echo "Verwerk issue #${ISSUE_NUM} met ${AI_PROVIDER}"
             echo "=========================================="
 
-            # Haal issue data op
-            ISSUE_JSON=$(gh issue view "$ISSUE_NUM" --json body,author,title)
-            ISSUE_BODY=$(echo "$ISSUE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['body'])")
-            ISSUE_AUTHOR=$(echo "$ISSUE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['author']['login'])")
-            ISSUE_TITLE=$(echo "$ISSUE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['title'][:60])")
+            # Haal issue data op en schrijf naar tijdelijk bestand (voorkomt shell-escaping problemen)
+            gh issue view "$ISSUE_NUM" --json body,author,title > /tmp/issue.json
+            echo "Issue JSON opgehaald:"
+            python3 -c "import json; d=json.load(open('/tmp/issue.json')); print(f'  Titel: {d[\"title\"][:60]}'); print(f'  Auteur: {d[\"author\"][\"login\"]}'); print(f'  Body lengte: {len(d[\"body\"])} chars')"
+
+            ISSUE_AUTHOR=$(python3 -c "import json; print(json.load(open('/tmp/issue.json'))['author']['login'])")
+            ISSUE_TITLE=$(python3 -c "import json; print(json.load(open('/tmp/issue.json'))['title'][:60])")
+
+            # Schrijf issue body naar apart bestand (kan multiline + speciale tekens bevatten)
+            python3 -c "import json; f=open('/tmp/issue_body.txt','w'); f.write(json.load(open('/tmp/issue.json'))['body']); f.close()"
 
             # Reactie: bezig
             gh issue comment "$ISSUE_NUM" \
               --body "⏳ **Bezig met genereren...** De les wordt nu automatisch gemaakt met **${AI_PROVIDER}**. Dit duurt 1-3 minuten."
 
-            # Draai het generatiescript
+            # Draai het generatiescript — body via bestand, niet via env var
             export ISSUE_NUMBER="$ISSUE_NUM"
-            export ISSUE_BODY
+            export ISSUE_BODY_FILE="/tmp/issue_body.txt"
             export ISSUE_AUTHOR
 
             if python3 .github/scripts/generate-lesson.py; then
@@ -125,14 +133,14 @@ jobs:
               PAGES_URL="https://${REPO_OWNER}.github.io/${REPO_NAME}"
 
               # Reactie: klaar
-              gh issue comment "$ISSUE_NUM" --body "$(cat <<EOF
+              gh issue comment "$ISSUE_NUM" --body "$(cat <<EOFCOMMENT
           ✅ **Les gegenereerd!** (met ${AI_PROVIDER})
 
           De les is aangemaakt en direct naar main gecommit.
 
           📄 [Bekijk de bestanden](https://github.com/${{ github.repository }}/tree/main/${LESSON_PATH%/*})
           🌐 [Bekijk de les](${PAGES_URL}/${LESSON_PATH})
-          EOF
+          EOFCOMMENT
               )"
 
               # Label als verwerkt en sluit
@@ -141,7 +149,7 @@ jobs:
             else
               echo "FOUT bij verwerken van issue #${ISSUE_NUM}"
               gh issue comment "$ISSUE_NUM" \
-                --body "❌ **Fout bij genereren met ${AI_PROVIDER}.** Er ging iets mis. Controleer of de foto's zichtbaar zijn en het formulier correct is ingevuld."
+                --body "❌ **Fout bij genereren met ${AI_PROVIDER}.** Er ging iets mis. Controleer de Actions-log voor details."
             fi
           done
 


### PR DESCRIPTION
- Issue body wordt nu naar /tmp/issue_body.txt geschreven om multiline content en speciale tekens correct te verwerken
- Python script leest body uit ISSUE_BODY_FILE als die bestaat
- Bredere foto-URL regex (GitHub user-attachments, private-user-images)
- Debug output toegevoegd voor betere troubleshooting in Actions logs
- set -euo pipefail voor betere error handling

https://claude.ai/code/session_01CyhbuCBYVKsSPzVWXbT1Z1