### PR TITLE
Kosten in issue-comment + home-link in breadcrumb

### DIFF
--- a/.github/scripts/lesson-prompt.txt
+++ b/.github/scripts/lesson-prompt.txt
@@ -40,7 +40,7 @@ Genereer EEN compleet HTML-bestand met de volgende structuur:
         <h1>{titel}</h1>
         <p>{ondertitel}</p>
     </header>
-    <nav class="breadcrumb">...</nav>
+    <nav class="breadcrumb"><a href="https://rwrw01.github.io/Claudecodedingetjes/">Home</a> &rsaquo; {vak} &rsaquo; {titel}</nav>
     <div class="container">
         <!-- Inhoudsopgave -->
         <!-- Theorie-secties met .card -->
@@ -56,7 +56,7 @@ Genereer EEN compleet HTML-bestand met de volgende structuur:
 
 ## Verplichte componenten
 1. **Header** met gradient achtergrond, titel en ondertitel
-2. **Breadcrumb** navigatie
+2. **Breadcrumb** navigatie met werkende link naar Home (https://rwrw01.github.io/Claudecodedingetjes/)
 3. **Inhoudsopgave** met anchor links
 4. **Theorie-secties** in .card containers met:
    - .formula boxes voor formules (blauwe linkerborder)

--- a/.github/workflows/generate-lesson.yml
+++ b/.github/workflows/generate-lesson.yml
@@ -135,16 +135,38 @@ jobs:
               REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
               PAGES_URL="https://${REPO_OWNER}.github.io/${REPO_NAME}"
 
+              # Lees kosten uit metadata
+              META_FILE="${LESSON_PATH%/*}/metadata.json"
+              COST_INFO=$(python3 -c "
+          import json
+          try:
+              meta = json.load(open('${META_FILE}'))
+              u = meta.get('usage', {})
+              if u and u.get('estimated_cost_usd'):
+                  inp = u.get('input_tokens', 0)
+                  out = u.get('output_tokens', 0)
+                  cost = u['estimated_cost_usd']
+                  print(f'💰 **Kosten:** {inp:,} input + {out:,} output tokens = **\${cost:.4f}** (~€{cost*0.92:.4f})')
+              else:
+                  print('')
+          except: print('')
+          ")
+
               # Reactie: klaar
-              gh issue comment "$ISSUE_NUM" --body "$(cat <<EOFCOMMENT
-          ✅ **Les gegenereerd!** (met ${AI_PROVIDER})
+              COMMENT_BODY="✅ **Les gegenereerd!** (met ${AI_PROVIDER})
 
           De les is aangemaakt en direct naar main gecommit.
 
           📄 [Bekijk de bestanden](https://github.com/${{ github.repository }}/tree/main/${LESSON_PATH%/*})
-          🌐 [Bekijk de les](${PAGES_URL}/${LESSON_PATH})
-          EOFCOMMENT
-              )"
+          🌐 [Bekijk de les](${PAGES_URL}/${LESSON_PATH})"
+
+              if [ -n "$COST_INFO" ]; then
+                COMMENT_BODY="${COMMENT_BODY}
+
+          ${COST_INFO}"
+              fi
+
+              gh issue comment "$ISSUE_NUM" --body "$COMMENT_BODY"
 
               # Label als verwerkt en sluit (maak label aan als het niet bestaat)
               gh label create "verwerkt" --color "0e8a16" --description "Les is gegenereerd" 2>/dev/null || true

--- a/rwrw01/maatschappijleer/havo-4-overheid-of-mensen-zelf/index.html
+++ b/rwrw01/maatschappijleer/havo-4-overheid-of-mensen-zelf/index.html
@@ -387,7 +387,7 @@
     </header>
 
     <nav class="breadcrumb">
-        <a href="#">Home</a> › <a href="#">Maatschappijleer</a> › <a href="#">HAVO 4</a> › Overheid of mensen zelf
+        <a href="https://rwrw01.github.io/Claudecodedingetjes/">Home</a> › Maatschappijleer › HAVO 4 › Overheid of mensen zelf
     </nav>
 
     <div class="container">


### PR DESCRIPTION
- Workflow toont nu token-gebruik en geschatte kosten in het issue-comment na succesvolle lesgeneratie
- Breadcrumb in lesson-prompt.txt linkt naar home pagina
- Bestaande maatschappijleer-les: breadcrumb links gefixed

https://claude.ai/code/session_01CyhbuCBYVKsSPzVWXbT1Z1