### PR TITLE
Fix: git pull --rebase voor push in workflow

### DIFF
--- a/.github/workflows/generate-lesson.yml
+++ b/.github/workflows/generate-lesson.yml
@@ -125,9 +125,10 @@ jobs:
                   break
           ")
 
-              # Commit en push
+              # Commit en push (met pull --rebase als remote vooruit is)
               git add -A
               git commit -m "Nieuwe les: ${ISSUE_TITLE} (issue #${ISSUE_NUM}, ${AI_PROVIDER})"
+              git pull --rebase origin main || true
               git push
 
               # GitHub Pages URL


### PR DESCRIPTION
Voorkomt push-failures wanneer main veranderd is tijdens de run (bijv. door een merge van een andere PR).

https://claude.ai/code/session_01CyhbuCBYVKsSPzVWXbT1Z1