### PR TITLE
Vereenvoudig: provider altijd via issue-label, niet via dropdown

### DIFF
--- a/.github/workflows/generate-lesson.yml
+++ b/.github/workflows/generate-lesson.yml
@@ -16,14 +16,6 @@ on:
         description: 'Issue nummer om te verwerken'
         required: true
         type: number
-      ai_provider:
-        description: 'AI provider'
-        required: false
-        default: 'claude'
-        type: choice
-        options:
-          - claude
-          - deepseek
 
 permissions:
   contents: write
@@ -77,8 +69,8 @@ jobs:
           # Beide API keys beschikbaar — script kiest de juiste op basis van AI_PROVIDER
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Standaard: claude. Bij workflow_dispatch kan je kiezen.
-          AI_PROVIDER: ${{ inputs.ai_provider || 'claude' }}
+          # Standaard: claude. Label 'deepseek' op issue overschrijft naar deepseek.
+          AI_PROVIDER: claude
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -105,12 +97,10 @@ jobs:
             python3 -c "import json; f=open('/tmp/issue_body.txt','w'); f.write(json.load(open('/tmp/issue.json'))['body']); f.close()"
 
             # Bepaal provider uit issue-labels (deepseek label overschrijft default)
-            if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
-              HAS_DEEPSEEK=$(gh issue view "$ISSUE_NUM" --json labels --jq '.labels[].name' | grep -c '^deepseek$' || true)
-              if [ "$HAS_DEEPSEEK" -gt 0 ]; then
-                export AI_PROVIDER="deepseek"
-                echo "  Provider overschreven door issue-label: deepseek"
-              fi
+            HAS_DEEPSEEK=$(gh issue view "$ISSUE_NUM" --json labels --jq '.labels[].name' | grep -c '^deepseek$' || true)
+            if [ "$HAS_DEEPSEEK" -gt 0 ]; then
+              export AI_PROVIDER="deepseek"
+              echo "  Provider overschreven door issue-label: deepseek"
             fi
 
             # Reactie: bezig


### PR DESCRIPTION
- workflow_dispatch heeft alleen nog 'issue nummer' input
- Provider wordt altijd bepaald door labels op het issue:
  - label 'deepseek' → DeepSeek + Tesseract OCR
  - geen label → Claude (standaard)
- Werkt voor alle triggers: label-event, cron, en workflow_dispatch

https://claude.ai/code/session_01CyhbuCBYVKsSPzVWXbT1Z1